### PR TITLE
fix page size handling in search

### DIFF
--- a/src/main/java/tla/backend/es/model/parts/ObjectReference.java
+++ b/src/main/java/tla/backend/es/model/parts/ObjectReference.java
@@ -38,7 +38,7 @@ public class ObjectReference implements Resolvable, Comparable<Resolvable> {
     @EqualsAndHashCode.Include
     @Field(type = FieldType.Keyword, index = false)
     private String _class;
-
+    
     @EqualsAndHashCode.Include
     @Field(type = FieldType.Keyword)
     private String eclass;

--- a/src/main/java/tla/backend/es/model/parts/ObjectReference.java
+++ b/src/main/java/tla/backend/es/model/parts/ObjectReference.java
@@ -36,6 +36,10 @@ public class ObjectReference implements Resolvable, Comparable<Resolvable> {
     private String id;
 
     @EqualsAndHashCode.Include
+    @Field(type = FieldType.Keyword, index = false)
+    private String _class;
+
+    @EqualsAndHashCode.Include
     @Field(type = FieldType.Keyword)
     private String eclass;
 
@@ -47,6 +51,14 @@ public class ObjectReference implements Resolvable, Comparable<Resolvable> {
     @Field(type = FieldType.Text)
     private String name;
 
+    @EqualsAndHashCode.Include
+    @Field(type = FieldType.Text)
+    private String pos;
+
+    @EqualsAndHashCode.Include
+    @Field(type = FieldType.Text)
+    private String variants;
+
     /**
      * An optional collection of ranges within the referenced object to which
      * the reference's subject refers to specifically. Only be used by
@@ -55,6 +67,13 @@ public class ObjectReference implements Resolvable, Comparable<Resolvable> {
     @JsonPropertyOrder(alphabetic = true)
     @Field(type = FieldType.Object, index = false)
     private List<Resolvable.Range> ranges;
+
+    public ObjectReference(String id, String eclass, String type, String name) {
+        this.id = id;
+        this.eclass = eclass;
+        this.type = type;
+        this.name = name;
+    }
 
     @Override
     public int compareTo(Resolvable arg0) {

--- a/src/main/java/tla/backend/es/query/ESQueryResult.java
+++ b/src/main/java/tla/backend/es/query/ESQueryResult.java
@@ -24,7 +24,7 @@ import tla.domain.dto.extern.PageInfo;
 public class ESQueryResult<T extends Indexable> {
 
     /**
-     * How many search results fit in one single page.
+     * How many search results fit in one single page by default.
      */
     public static final int SEARCH_RESULT_PAGE_SIZE = 20;
 
@@ -102,15 +102,15 @@ public class ESQueryResult<T extends Indexable> {
         return PageInfo.builder()
             .number(pageable.getPageNumber())
             .totalElements(hits.getTotalHits())
-            .size(SEARCH_RESULT_PAGE_SIZE)
+            .size(pageable.getPageSize())
             .numberOfElements(
                 Math.min(
-                    SEARCH_RESULT_PAGE_SIZE,
+                    pageable.getPageSize(),
                     hits.getSearchHits().size()
                 )
             ).totalPages(
-                (int) hits.getTotalHits() / SEARCH_RESULT_PAGE_SIZE + (
-                    hits.getTotalHits() % SEARCH_RESULT_PAGE_SIZE < 1 ? 0 : 1
+                (int) hits.getTotalHits() / pageable.getPageSize() + (
+                    hits.getTotalHits() % pageable.getPageSize() < 1 ? 0 : 1
                 )
             ).build();
     }

--- a/src/test/java/tla/backend/es/model/ObjectReferenceTest.java
+++ b/src/test/java/tla/backend/es/model/ObjectReferenceTest.java
@@ -51,7 +51,7 @@ public class ObjectReferenceTest {
             .paths(
                 new ObjectPath[]{
                     ObjectPath.of(
-                        new ObjectReference("ID2", "BTSThsEntry", "date", "Thut")
+                        new ObjectReference("ID2", null,"BTSThsEntry", "date", "Thut", null,null,null)
                     )
                 }
             ).build();

--- a/src/test/java/tla/backend/es/model/ObjectReferenceTest.java
+++ b/src/test/java/tla/backend/es/model/ObjectReferenceTest.java
@@ -51,7 +51,7 @@ public class ObjectReferenceTest {
             .paths(
                 new ObjectPath[]{
                     ObjectPath.of(
-                        new ObjectReference("ID2", "BTSThsEntry", "date", "Thut", null)
+                        new ObjectReference("ID2", "BTSThsEntry", "date", "Thut")
                     )
                 }
             ).build();


### PR DESCRIPTION
search endpoints such as `/sentence/search` currently only support the default page size of 20 results at once because the actual page size as specified via the `&size` URL parameter in requests isn't taken into account during calculation of the pagination information of the results. These changes fix that issue by handling the `&size` parameter so that it can be used to specify the desired number of results per page.

It is therefore possible to request a certain amount of search results per page in a search request like this:

```bash
curl -X POST -H "Content-Type: application/json" "http://localhost:8090/sentence/search?size=10" -d @q-occ-lemma.json
```

...or, in a more simple manner (using HTTPie):

```bash
http post :8090/sentence/search size==10 < q-occ-lemma.json
```

...assuming that there is a file `q-occ-lemma.json` with content such as e.g.:

```json
{
    "@class": "tla.domain.command.SentenceSearch",
    "tokens": [
        {
            "lemma": {
                "id": "10050"
            }
        }
    ],
    "@dto": "tla.domain.dto.SentenceDto"
}
```

hope this helps.